### PR TITLE
When storing the squenceId Object.writeFileSync expects an string

### DIFF
--- a/scripts/notify-new-listings.js
+++ b/scripts/notify-new-listings.js
@@ -43,7 +43,7 @@ const queryEvents = (args) => {
 
 const saveLastEventSequenceId = (sequenceId) => {
   try {
-    fs.writeFileSync(stateFile, sequenceId);
+    fs.writeFileSync(stateFile, sequenceId.toString());
   } catch (err) {
     throw err;
   }


### PR DESCRIPTION
```
 [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number
```